### PR TITLE
Add abstract roles

### DIFF
--- a/lib/aria/index.js
+++ b/lib/aria/index.js
@@ -23,7 +23,7 @@ exports.getRole = (el) => {
   let role = null;
   // Should be the first non-abstract role in the list
   if ((el.getAttribute('role') || '').split(/\s+/).some((name) => {
-    if (roles[name]) {
+    if (roles[name] && !roles[name].abstract) {
       role = name;
       return true;
     }
@@ -32,6 +32,25 @@ exports.getRole = (el) => {
     return role;
   }
   return match(el).implicitRoles[0] || null;
+};
+
+/**
+ * Does an element have a role. This will test against abstract roles
+ * @param {Element} el
+ * @param {String} name
+ * @returns {Boolean}
+ */
+exports.hasRole = (el, name) => {
+  const actualRole = exports.getRole(el);
+  if (!actualRole) {
+    return false;
+  }
+  return [name].some(function hasRole(checkRole) {
+    if (checkRole === actualRole) {
+      return true;
+    }
+    return (roles[checkRole].subclass || []).some(hasRole);
+  });
 };
 
 /**

--- a/lib/aria/roles.js
+++ b/lib/aria/roles.js
@@ -7,6 +7,7 @@
 module.exports = {
   alert: {
     allowed: ['expanded'],
+    subclass: ['alertdialog'],
   },
   alertdialog: {
     allowed: ['expanded', 'modal'],
@@ -26,10 +27,12 @@ module.exports = {
   },
   cell: {
     nameFromContent: true,
+    subclass: ['columnheader', 'gridcell', 'rowheader'],
   },
   checkbox: {
     required: ['checked'],
     nameFromContent: true,
+    subclass: ['menuitemcheckbox', 'switch'],
   },
   columnheader: {
     allowed: ['sort', 'readonly', 'required', 'selected', 'expanded'],
@@ -39,8 +42,16 @@ module.exports = {
     required: ['expanded'],
     allowed: ['autocomplete', 'required', 'activedescendant'],
   },
+  command: {
+    abstract: true,
+    subclass: ['button', 'link', 'menuitem'],
+  },
   complementary: {
     allowed: ['expanded'],
+  },
+  composite: {
+    abstract: true,
+    subclass: ['grid', 'select', 'spinbutton', 'tablist'],
   },
   contentinfo: {
     allowed: ['expanded'],
@@ -50,12 +61,14 @@ module.exports = {
   },
   dialog: {
     allowed: ['expanded'],
+    subclass: ['alertdialog'],
   },
   directory: {
     allowed: ['expanded'],
   },
   document: {
     allowed: ['expanded'],
+    subclass: ['article'],
   },
   feed: {
     allowed: ['setsize', 'expanded'],
@@ -68,13 +81,16 @@ module.exports = {
   },
   grid: {
     allowed: ['level', 'multiselectable', 'readonly', 'activedescendant', 'expanded'],
+    subclass: ['treegrid'],
   },
   gridcell: {
     allowed: ['readonly', 'required', 'selected', 'expanded'],
     nameFromContent: true,
+    subclass: ['columnheader', 'rowheader'],
   },
   group: {
     allowed: ['activedescendant', 'expanded'],
+    subclass: ['row', 'select', 'toolbar'],
   },
   heading: {
     allowed: ['level', 'expanded'],
@@ -83,18 +99,28 @@ module.exports = {
   img: {
     allowed: ['expanded'],
   },
+  input: {
+    abstract: true,
+    subclass: ['checkbox', 'option', 'radio', 'slider', 'spinbutton', 'textbox'],
+  },
+  landmark: {
+    abstract: true,
+    subclass: ['banner', 'complementary', 'contentinfo', 'form', 'main', 'navigation', 'region', 'search'],
+  },
   link: {
     allowed: ['expanded'],
     nameFromContent: true,
   },
   list: {
     allowed: ['expanded'],
+    subclass: ['directory', 'feed'],
   },
   listbox: {
     allowed: ['multiselectable', 'required', 'expanded', 'activedescendant', 'expanded'],
   },
   listitem: {
     allowed: ['level', 'posinset', 'setsize', 'expanded'],
+    subclass: ['treeitem'],
   },
   log: {
     allowed: ['expanded'],
@@ -110,16 +136,19 @@ module.exports = {
   },
   menu: {
     allowed: ['activedescendant', 'expanded'],
+    subclass: ['menubar'],
   },
   menubar: {
     allowed: ['activedescendant'],
   },
   menuitem: {
     nameFromContent: true,
+    subclass: ['menuitemcheckbox'],
   },
   menuitemcheckbox: {
     required: ['checked'],
     nameFromContent: true,
+    subclass: ['menuitemradio'],
   },
   menuitemradio: {
     required: ['checked'],
@@ -129,12 +158,14 @@ module.exports = {
   navigation: {
     allowed: ['expanded'],
   },
+  none: {},
   note: {
     allowed: ['expanded'],
   },
   option: {
     allowed: ['checked', 'posinset', 'selected', 'setsize'],
     nameFromContent: true,
+    subclass: ['treeitem'],
   },
   presentation: {},
   progressbar: {
@@ -144,12 +175,21 @@ module.exports = {
     required: ['checked'],
     allowed: ['posinset', 'selected', 'setsize'],
     nameFromContent: true,
+    subclass: ['menuitemradio'],
   },
   radiogroup: {
     allowed: ['required', 'activedescendant', 'expanded'],
   },
+  range: {
+    abstract: true,
+    subclass: ['progressbar', 'scrollbar', 'slider', 'spinbutton'],
+  },
   region: {
     allowed: ['expanded'],
+  },
+  roletype: {
+    abstract: true,
+    subclass: ['structure', 'widget', 'window'],
   },
   row: {
     allowed: [
@@ -176,6 +216,18 @@ module.exports = {
   searchbox: {
     allowed: ['activedescendant', 'autocomplete', 'multiline', 'placeholder', 'readonly', 'required'],
   },
+  section: {
+    abstract: true,
+    subclass: ['alert', 'cell', 'definition', 'figure', 'group', 'img', 'landmark', 'list', 'listitem', 'log', 'marquee', 'math', 'note', 'status', 'table', 'tabpanel', 'term', 'tooltip'],
+  },
+  sectionhead: {
+    abstract: true,
+    subclass: ['columnheader', 'heading', 'rowheader', 'tab'],
+  },
+  select: {
+    abstract: true,
+    subclass: ['combobox', 'listbox', 'menu', 'radiogroup', 'tree'],
+  },
   separator: {
     allowed: ['valuetext'],
   },
@@ -189,6 +241,11 @@ module.exports = {
   },
   status: {
     allowed: ['expanded'],
+    subclass: ['timer'],
+  },
+  structure: {
+    abstract: true,
+    subclass: ['application', 'document', 'none', 'presentation', 'rowgroup', 'section', 'sectionhead', 'separator'],
   },
   switch: {
     required: ['checked'],
@@ -200,6 +257,7 @@ module.exports = {
   },
   table: {
     allowed: ['colcount', 'rowcount'],
+    subclass: ['grid'],
   },
   tablist: {
     allowed: ['level', 'activedescendant', 'expanded'],
@@ -212,6 +270,7 @@ module.exports = {
   },
   textbox: {
     allowed: ['activedescendant', 'autocomplete', 'multiline', 'placeholder', 'readonly', 'required'],
+    subclass: ['searchbox'],
   },
   timer: {
     allowed: ['expanded'],
@@ -226,11 +285,20 @@ module.exports = {
   tree: {
     allowed: ['multiselectable', 'required', 'activedescendant', 'expanded'],
     nameFromContent: true,
+    subclass: ['treegrid'],
   },
   treegrid: {
     allowed: ['level', 'multiselecteable', 'readonly', 'activedescendant', 'expanded', 'required'],
   },
   treeitem: {
     allowed: ['level', 'posinset', 'setsize', 'expanded', 'checked', 'selected'],
+  },
+  widget: {
+    abstract: true,
+    subclass: ['command', 'composite', 'gridcell', 'input', 'range', 'row', 'separator', 'tab'],
+  },
+  window: {
+    abstract: true,
+    subclass: ['dialog'],
   },
 };

--- a/rules/aria/roles/rule.js
+++ b/rules/aria/roles/rule.js
@@ -15,6 +15,11 @@
         return true;
       }
 
+      if (aria.roles[name].abstract) {
+        error = `"${name}" is an abstract role and should not be used`;
+        return true;
+      }
+
       if (rule.implicitRoles.includes(name)) {
         error = `role "${name}" is implicit for this element and should not be specified`;
         return true;

--- a/rules/aria/roles/spec.js
+++ b/rules/aria/roles/spec.js
@@ -16,7 +16,13 @@ before(() => {
     };
   };
 
-  aria.roles = { implicit: {}, allowed1: {}, allowed2: {}, disallowed: {} };
+  aria.roles = {
+    implicit: {},
+    allowed1: {},
+    allowed2: {},
+    disallowed: {},
+    abstract: { abstract: true },
+  };
 });
 
 after(() => {
@@ -70,6 +76,19 @@ context('using an unknown role', () => {
 
   it('adds an error', when(() => {
     el = appendToBody('<test role="unknown" />');
+  }).then(() => {
+    expect(logger).toHaveEntries([rule, el]);
+  }));
+});
+
+context('using an abstract role', () => {
+  it('generates the expected error message', () => {
+    el = appendToBody('<test role="abstract" />');
+    expect(rule).toGenerateErrorMessage({ for: el }, '"abstract" is an abstract role and should not be used');
+  });
+
+  it('adds an error', when(() => {
+    el = appendToBody('<test role="abstract" />');
   }).then(() => {
     expect(logger).toHaveEntries([rule, el]);
   }));


### PR DESCRIPTION
- Added role hierarchy to `aria.roles`
- Updated role rules to warn about abstract roles
- Added `aria.hasRole` to test if an element belongs to an abstract role