### PR TITLE
Button type inputs use `value` for their native label

### DIFF
--- a/lib/config/elements.js
+++ b/lib/config/elements.js
@@ -112,6 +112,10 @@ module.exports = {
         return el.alt || el.value || '';
       }
 
+      if (['submit', 'reset', 'button'].includes(el.type)) {
+        return el.value;
+      }
+
       return labels(el, utils);
     },
   },

--- a/test/specs/config.js
+++ b/test/specs/config.js
@@ -467,6 +467,15 @@ describe('config', () => {
           });
         });
 
+        ['submit', 'reset', 'button'].forEach((type) => {
+          describe(`<input[type=${type}]>`, () => {
+            it('uses value as the native label', () => {
+              const label = appendToBody(`<label><input type="${type}" value="bar">foo</label>`);
+              expect(elements.input.nativeLabel(label.querySelector('input'), utils)).toEqual('bar');
+            });
+          });
+        });
+
         describe('<input[type=image]>', () => {
           it('uses the alt text as a native label', () => {
             const label = appendToBody('<label><input type="image" alt="bar">foo</label>');


### PR DESCRIPTION
fixes #82 